### PR TITLE
Transliterate messages before sending

### DIFF
--- a/app/qml/pages/ManagerPage.qml
+++ b/app/qml/pages/ManagerPage.qml
@@ -41,7 +41,7 @@ Page {
         id: settings
         path: "/org/pebbled/settings"
         property bool silentWhenConnected: false
-        property bool transliterateCyrillic: false
+        property bool transliterateMessage: false
         property bool incomingCallNotification: true
         property bool notificationsCommhistoryd: true
         property bool notificationsMissedCall: true
@@ -159,11 +159,12 @@ Page {
                 }
             }
             TextSwitch {
-                text: qsTr("Transliterate Cyrillic")
-                checked: settings.transliterateCyrillic
+                text: qsTr("Transliterate messages")
+                description: qsTr("Messages will be transliterated to ASCII before sending to Pebble")
+                checked: settings.transliterateMessage
                 automaticCheck: false
                 onClicked: {
-                    settings.transliterateCyrillic = !settings.transliterateCyrillic;
+                    settings.transliterateMessage = !settings.transliterateMessage;
                 }
             }
 

--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -9,6 +9,7 @@ PKGCONFIG += mlite5
 QMAKE_CXXFLAGS += -std=c++0x
 
 LIBS += -llog4qt
+LIBS += -licuuc -licui18n
 
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 

--- a/daemon/manager.h
+++ b/daemon/manager.h
@@ -16,6 +16,8 @@
 #include <MNotification>
 #include <Log4Qt/Logger>
 
+#include <unicode/translit.h>
+
 using namespace QtContacts;
 
 class Manager :
@@ -50,6 +52,8 @@ class Manager :
 
     QString lastSeenMpris;
 
+    QScopedPointer<icu::Transliterator> transliterator;
+
 public:
     explicit Manager(watch::WatchConnector *watch, DBusConnector *dbus, VoiceCallManager *voice, NotificationManager *notifications, Settings *settings);
 
@@ -60,7 +64,7 @@ public:
     QVariantMap getMprisMetadata() { return mprisMetadata; }
 
 protected:
-    void transliterateCyrillic(const QString &text);
+    void transliterateMessage(const QString &text);
 
 signals:
     void mprisMetadataChanged(QVariantMap);

--- a/daemon/settings.h
+++ b/daemon/settings.h
@@ -8,7 +8,7 @@ class Settings : public MDConfGroup
     Q_OBJECT
 
     Q_PROPERTY(bool silentWhenConnected MEMBER silentWhenConnected NOTIFY silentWhenConnectedChanged)
-    Q_PROPERTY(bool transliterateCyrillic MEMBER transliterateCyrillic NOTIFY transliterateCyrillicChanged)
+    Q_PROPERTY(bool transliterateMessage MEMBER transliterateMessage NOTIFY transliterateMessageChanged)
     Q_PROPERTY(bool incomingCallNotification MEMBER incomingCallNotification NOTIFY incomingCallNotificationChanged)
     Q_PROPERTY(bool notificationsCommhistoryd MEMBER notificationsCommhistoryd NOTIFY notificationsCommhistorydChanged)
     Q_PROPERTY(bool notificationsMissedCall MEMBER notificationsMissedCall NOTIFY notificationsMissedCallChanged)
@@ -19,7 +19,7 @@ class Settings : public MDConfGroup
     Q_PROPERTY(bool notificationsOther MEMBER notificationsOther NOTIFY notificationsOtherChanged)
     Q_PROPERTY(bool notificationsAll MEMBER notificationsAll NOTIFY notificationsAllChanged)
     bool silentWhenConnected;
-    bool transliterateCyrillic;
+    bool transliterateMessage;
     bool incomingCallNotification;
     bool notificationsCommhistoryd;
     bool notificationsMissedCall;
@@ -37,7 +37,7 @@ public:
 
 signals:
     void silentWhenConnectedChanged(bool);
-    void transliterateCyrillicChanged(bool);
+    void transliterateMessageChanged(bool);
     void incomingCallNotificationChanged(bool);
     void notificationsCommhistorydChanged(bool);
     void notificationsMissedCallChanged(bool);

--- a/rpm/pebble.yaml
+++ b/rpm/pebble.yaml
@@ -24,6 +24,7 @@ PkgConfigBR:
 - sailfishapp >= 0.0.10
 PkgBR:
 - log4qt-devel
+- libicu-devel
 Requires:
 - sailfishsilica-qt5 >= 0.10.9
 - systemd-user-session-targets


### PR DESCRIPTION
Default pebble firmware does not support cyrillic letters. Option to transliterate messages before sending them to pebble.
