### PR TITLE
Added queue for notifications to prevent pebble from crashing fixes #20

### DIFF
--- a/daemon/notificationmanager.h
+++ b/daemon/notificationmanager.h
@@ -7,8 +7,50 @@
 
 #include <QDBusInterface>
 #include <QDBusPendingCallWatcher>
+#include <QThread>
+#include <QQueue>
+#include <QMutex>
+#include <QWaitCondition>
 
 typedef QHash<QString, QString> QStringHash;
+
+enum {
+    notificationEMAIL = 0,
+    notificationSMS = 1,
+    notificationFACEBOOK = 2,
+    notificationTWITTER = 3
+};
+
+struct NotificationManagerMessage
+{
+    int type;
+    QString subject;
+    QString data;
+    QString sender;
+
+    NotificationManagerMessage() {}
+    NotificationManagerMessage(const int &type, const QString &sender, const QString &data, const QString &subject = QString())
+        : type(type), subject(subject), data(data), sender(sender) {}
+};
+
+Q_DECLARE_METATYPE(NotificationManagerMessage)
+
+class NotificationManagerQueueHandler : public QThread
+{
+    Q_OBJECT
+public:
+    explicit NotificationManagerQueueHandler(QObject *parent = 0);
+            ~NotificationManagerQueueHandler();
+    void queueNotification(const NotificationManagerMessage &notification);
+Q_SIGNALS:
+    void notificationReady(const NotificationManagerMessage &notification);
+protected:
+    void run();
+private:
+    QMutex *mutex;
+    QQueue<NotificationManagerMessage> *queue;
+    QWaitCondition waitcond;
+};
 
 class NotificationManager : public QObject
 {
@@ -32,6 +74,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void Notify(const QString &app_name, uint replaces_id, const QString &app_icon, const QString &summary, const QString &body, const QStringList &actions, const QVariantHash &hints, int expire_timeout);
+    void onQueuedNotification(const NotificationManagerMessage &notification);
 
 protected Q_SLOTS:
     void initialize(bool notifyError = false);
@@ -42,6 +85,7 @@ private:
     QString getCleanAppName(QString app_name);
     QStringHash getCategoryParams(QString category);
     Settings *settings;
+    NotificationManagerQueueHandler *queueHandler;
 
     Q_DISABLE_COPY(NotificationManager)
     Q_DECLARE_PRIVATE(NotificationManager)


### PR DESCRIPTION
I added a queue system which only sends one notification every 250ms to the pebble.
I tested with 256 messages in the queue and pebble does not crash. (crashes if you don't delay)

Queuing is in a thread so it does not interfere with other pebble communication.
