### PR TITLE
Adding support for accepting calls

### DIFF
--- a/daemon/manager.cpp
+++ b/daemon/manager.cpp
@@ -34,6 +34,7 @@ Manager::Manager(watch::WatchConnector *watch, DBusConnector *dbus, VoiceCallMan
 
     connect(watch, SIGNAL(messageDecoded(uint,QByteArray)), commands, SLOT(processMessage(uint,QByteArray)));
     connect(commands, SIGNAL(hangup()), SLOT(hangupAll()));
+    connect(commands, SIGNAL(answer()), SLOT(answerAll()));
 
     PebbledProxy *proxy = new PebbledProxy(this);
     PebbledAdaptor *adaptor = new PebbledAdaptor(proxy);
@@ -251,6 +252,13 @@ void Manager::hangupAll()
 {
     foreach (VoiceCallHandler* handler, voice->voiceCalls()) {
         handler->hangup();
+    }
+}
+
+void Manager::answerAll()
+{
+    foreach (VoiceCallHandler* handler, voice->voiceCalls()) {
+        handler->answer();
     }
 }
 

--- a/daemon/manager.h
+++ b/daemon/manager.h
@@ -71,6 +71,7 @@ signals:
 
 public slots:
     void hangupAll();
+    void answerAll();
     void applyProfile();
 
 protected slots:

--- a/daemon/watchcommands.cpp
+++ b/daemon/watchcommands.cpp
@@ -21,6 +21,9 @@ void WatchCommands::processMessage(uint endpoint, QByteArray data)
         if (data.at(0) == WatchConnector::callHANGUP) {
             emit hangup();
         }
+        if (data.at(0) == WatchConnector::callANSWER) {
+            emit answer();
+        }
         break;
     case WatchConnector::watchMUSIC_CONTROL:
         musicControl(WatchConnector::MusicControl(data.at(0)));

--- a/daemon/watchcommands.h
+++ b/daemon/watchcommands.h
@@ -18,6 +18,7 @@ public:
 
 signals:
     void hangup();
+    void answer();
 
 public slots:
     void processMessage(uint endpoint, QByteArray data);

--- a/daemon/watchconnector.cpp
+++ b/daemon/watchconnector.cpp
@@ -241,7 +241,7 @@ QByteArray WatchConnector::buildMessageData(uint lead, QStringList data)
 void WatchConnector::sendPhoneVersion()
 {
     unsigned int sessionCap = sessionCapGAMMA_RAY;
-    unsigned int remoteCap = remoteCapTELEPHONY | remoteCapSMS | osANDROID;
+    unsigned int remoteCap = remoteCapTELEPHONY | remoteCapSMS | osIOS;
     QByteArray res;
 
     //Prefix


### PR DESCRIPTION
While trying to figure out how to get the "x" button to notifications i noticed if i send IOS as operating system, it displays an answer button on the incomming cal dialog.

So this PR changes osANDROID to osIOS and added the nessasary glue to answer calls :)
Changing the operating system seams to have no negative effect.