### PR TITLE
Automatically synchronize time with watch

### DIFF
--- a/daemon/watchconnector.cpp
+++ b/daemon/watchconnector.cpp
@@ -155,7 +155,7 @@ void WatchConnector::disconnect()
     socket->deleteLater();
     reconnectTimer.stop();
     timeSyncTimer.stop();
-    qCDebug(l) << "stopped reconnect timer";
+    qCDebug(l) << "stopped timers";
 }
 
 void WatchConnector::handleWatch(const QString &name, const QString &address)
@@ -337,7 +337,7 @@ void WatchConnector::onDisconnected()
     if (not writeData.isEmpty() && reconnectTimer.interval() > RECONNECT_TIMEOUT) {
         writeData.clear(); // 3rd time around - user is not here, do not bother with resending last message
     }
-
+    timeSyncTimer.stop();
     scheduleReconnect();
 
 }
@@ -481,6 +481,7 @@ void WatchConnector::ping(uint cookie)
 
 void WatchConnector::time()
 {
+    qCDebug(l) << "Synchronizing time";
     timeSyncTimer.stop();
     QByteArray res;
     QDateTime UTC(QDateTime::currentDateTimeUtc());

--- a/daemon/watchconnector.cpp
+++ b/daemon/watchconnector.cpp
@@ -70,7 +70,7 @@ WatchConnector::WatchConnector(QObject *parent) :
     connect(&reconnectTimer, SIGNAL(timeout()), SLOT(reconnect()));
     timeSyncTimer.setSingleShot(true);
     connect(&timeSyncTimer, SIGNAL(timeout()), SLOT(time()));
-    timeSyncTimer.setInterval(14400000);
+    timeSyncTimer.setInterval(4 * 60 * 60 * 1000); // sync time every 4 hours
 
     firmwareMapping.insert(UNKNOWN, "unknown");
     firmwareMapping.insert(PEBBLE_ONE_EV1, "ev1");

--- a/daemon/watchconnector.h
+++ b/daemon/watchconnector.h
@@ -261,6 +261,7 @@ private:
     bool is_connected;
     QByteArray writeData;
     QTimer reconnectTimer;
+    QTimer timeSyncTimer;
     QString _last_name;
     QString _last_address;
     WatchVersions _versions;


### PR DESCRIPTION
Time sync will occur on connect, and every 4 hours henceforth. Re-connection and manual sync request will perform a sync and reset the timer.