### PR TITLE
Pebble Time fixes

### DIFF
--- a/daemon/watchconnector.cpp
+++ b/daemon/watchconnector.cpp
@@ -598,7 +598,91 @@ void WatchConnector::sendNotification(uint lead, QString sender, QString data, Q
         }
         break;
     case BASALT: {
-        qCWarning(l) << "Tried sending notification to unsupported watch platform" << lead << sender << data << subject;
+        int source;
+        switch (lead) {
+        case leadEMAIL:
+            source = 19;
+            break;
+        case leadFACEBOOK:
+            source = 11;
+            break;
+        case leadSMS:
+            source = 45;
+            break;
+        case leadTWITTER:
+            source = 6;
+            break;
+        default:
+            source = 1;
+        }
+
+        int attributesCount = 0;
+        QByteArray attributes;
+
+        attributesCount++;
+        QByteArray senderBytes = sender.left(64).toUtf8();
+        attributes.append(0x01); // id = title
+        attributes.append(senderBytes.length() & 0xFF); attributes.append(((senderBytes.length() >> 8) & 0xFF)); // length
+        attributes.append(senderBytes); // content
+
+        attributesCount++;
+        QByteArray subjectBytes = (subject.isEmpty() ? data : subject).left(64).toUtf8();
+        attributes.append(0x02); // id = subtitle
+        attributes.append(subjectBytes.length() & 0xFF); attributes.append((subjectBytes.length() >> 8) & 0xFF); // length
+        attributes.append(subjectBytes); //content
+
+        if (!data.isEmpty()) {
+            attributesCount++;
+            QByteArray dataBytes = data.left(512).toUtf8();
+            attributes.append(0x03); // id = body
+            attributes.append(dataBytes.length() & 0xFF); attributes.append((dataBytes.length() >> 8) & 0xFF); // length
+            attributes.append(dataBytes); // content
+        }
+
+        attributesCount++;
+        attributes.append(0x04); // id = tinyicon
+        attributes.append(0x04); attributes.append('\0'); // length
+        attributes.append(source); attributes.append('\0'); attributes.append('\0'); attributes.append('\0'); // content
+
+
+        QByteArray actions;
+        actions.append('\0'); // action id
+        actions.append(0x04); // type = dismiss
+        actions.append(0x01); // attributes length = 1
+        actions.append(0x01); // attribute id = title
+        actions.append(0x07); actions.append('\0'); // attribute length
+        actions.append("Dismiss"); // attribute content
+
+
+        QByteArray itemId = QUuid::createUuid().toRfc4122();
+        int time = QDateTime::currentMSecsSinceEpoch() / 1000;
+        QByteArray item;
+        item.append(itemId); // item id
+        item.append(QUuid().toRfc4122()); // parent id
+        item.append(time & 0xFF); item.append((time >> 8) & 0xFF); item.append((time >> 16) & 0xFF); item.append((time >> 24) & 0xFF); // timestamp
+        item.append('\0'); item.append('\0'); // duration
+        item.append(0x01); // type: notification
+        item.append('\0'); item.append('\0'); // flags
+        item.append(0x01); // layout
+
+        int length = attributes.length() + actions.length();
+        item.append(length & 0xFF); item.append((length >> 8) & 0xFF); // data length
+        item.append(attributesCount); // attributes count
+        item.append(0x01); // actions count
+        item.append(attributes);
+        item.append(actions);
+
+        int token = (qrand() % ((int)pow(2, 16) - 2)) + 1;
+        QByteArray blob;
+        blob.append(0x01); // command = insert
+        blob.append(token & 0xFF); blob.append((token >> 8) & 0xFF); // token
+        blob.append(0x04); //database id = notification
+        blob.append(itemId.length() & 0xFF); // key length
+        blob.append(itemId); // key
+        blob.append(item.length() & 0xFF); blob.append((item.length() >> 8) & 0xFF); // value length
+        blob.append(item);
+
+        sendMessage(watchBLOB_DB, blob);
         }
         break;
     default:

--- a/daemon/watchconnector.cpp
+++ b/daemon/watchconnector.cpp
@@ -89,6 +89,7 @@ WatchConnector::WatchConnector(QObject *parent) :
     hardwareMapping.insert(BIANCA, HWMap(APLITE, "v2_0"));
     hardwareMapping.insert(SNOWY_EVT2, HWMap(BASALT, "snowy_evt2"));
     hardwareMapping.insert(SNOWY_DVT, HWMap(BASALT, "snowy_dvt"));
+    hardwareMapping.insert(BOBBY_SMILES, HWMap(BASALT, "snowy_s3"));
     hardwareMapping.insert(TINTIN_BB, HWMap(APLITE, "bigboard"));
     hardwareMapping.insert(TINTIN_BB2, HWMap(APLITE, "bb2"));
     hardwareMapping.insert(SNOWY_BB, HWMap(BASALT, "snowy_bb"));

--- a/daemon/watchconnector.h
+++ b/daemon/watchconnector.h
@@ -161,6 +161,7 @@ public:
         BIANCA = 6,
         SNOWY_EVT2 = 7,
         SNOWY_DVT = 8,
+        BOBBY_SMILES = 10,
 
         TINTIN_BB = 0xFF,
         TINTIN_BB2 = 0xFE,


### PR DESCRIPTION
These changes add the necessary hardware mapping for the Pebble Time Steel and add basic support for creating timeline pins for notifications.

Supporting the creation of timeline pins is a bit messy and might need to be refactored. But it at least works and makes a lot of Pebble Time and Jolla owners happy :smile:.