### PR TITLE
Support JS timers

### DIFF
--- a/daemon/jskitmanager.cpp
+++ b/daemon/jskitmanager.cpp
@@ -155,8 +155,12 @@ void JSKitManager::startJsApp()
 
     // Shims for compatibility...
     QJSValue result = _engine->evaluate(
-                "function XMLHttpRequest() { return Pebble.createXMLHttpRequest(); }\n"
-                );
+                "function XMLHttpRequest() { return Pebble.createXMLHttpRequest(); }\n\
+                function setInterval(func, time) { return Pebble.setInterval(func, time); }\n\
+                function clearInterval(id) { Pebble.clearInterval(id); }\n\
+                function setTimeout(func, time) { return Pebble.setTimeout(func, time); }\n\
+                function clearTimeout(id) { Pebble.clearTimeout(id); }\n\
+                ");
     Q_ASSERT(!result.isError());
 
     // Polyfills...

--- a/daemon/jskitobjects.h
+++ b/daemon/jskitobjects.h
@@ -19,6 +19,12 @@ public:
     Q_INVOKABLE void addEventListener(const QString &type, QJSValue function);
     Q_INVOKABLE void removeEventListener(const QString &type, QJSValue function);
 
+    Q_INVOKABLE int setInterval(QJSValue expression, int delay);
+    Q_INVOKABLE void clearInterval(int timerId);
+
+    Q_INVOKABLE int setTimeout(QJSValue expression, int delay);
+    Q_INVOKABLE void clearTimeout(int timerId);
+
     Q_INVOKABLE uint sendAppMessage(QJSValue message, QJSValue callbackForAck = QJSValue(), QJSValue callbackForNack = QJSValue());
 
     Q_INVOKABLE void showSimpleNotificationOnPebble(const QString &title, const QString &body);
@@ -32,6 +38,9 @@ public:
 
     void invokeCallbacks(const QString &type, const QJSValueList &args = QJSValueList());
 
+protected:
+    void timerEvent(QTimerEvent *event);
+
 private:
     QJSValue buildAckEventObject(uint transaction, const QString &message = QString()) const;
 
@@ -39,6 +48,8 @@ private:
     AppInfo _appInfo;
     JSKitManager *_mgr;
     QHash<QString, QList<QJSValue>> _callbacks;
+    QHash<int, QJSValue> _intervals;
+    QHash<int, QJSValue> _timeouts;
 };
 
 class JSKitConsole : public QObject


### PR DESCRIPTION
Add support to set and clear Interval and Timeout timers for Javascript
apps. The QT JS engine doesn't support them natively.

Fixes #78