### PR TITLE
Added support for pebble-time appstore fixes #79

### DIFF
--- a/app/pebblestoreview.h
+++ b/app/pebblestoreview.h
@@ -16,11 +16,14 @@ public:
     Q_PROPERTY(bool loggedin READ loggedin NOTIFY accessTokenChanged)
     Q_PROPERTY(bool downloadInProgress READ downloadInProgress NOTIFY downloadInProgressChanged)
     Q_PROPERTY(QString accessToken READ accessToken WRITE setAccessToken NOTIFY accessTokenChanged)
+    Q_PROPERTY(QString hardwarePlatform READ hardwarePlatform WRITE setHardwarePlatform NOTIFY hardwarePlatformChanged)
 
     bool loggedin();
     bool downloadInProgress();
     QString accessToken() const;
     void setAccessToken(const QString &accessToken);
+    QString hardwarePlatform() const;
+    void setHardwarePlatform(const QString &hardwarePlatform);
 
 public slots:
     void gotoWatchFaces();
@@ -34,6 +37,7 @@ private slots:
 
 signals:
     void accessTokenChanged(const QString & accessToken);
+    void hardwarePlatformChanged(const QString & hardwarePlatform);
     void downloadPebbleApp(const QString & downloadTitle, const QString & downloadUrl);
     void downloadInProgressChanged();
     void titleChanged(const QString & title);
@@ -42,11 +46,13 @@ private:
     QNetworkAccessManager* m_networkManager;
     QUrl m_configUrl;
     QString m_accessToken;
+    QString m_hardwarePlatform;
     QJsonObject downloadObject;
     QJsonObject storeConfigObject;
     bool m_downloadInProgress;
 
     QUrl prepareUrl(QString baseUrl);
+    void fetchConfig();
     void fetchData(QUrl url);
     void addToLocker(QJsonObject data);
     void removeFromLocker(QJsonObject data);

--- a/app/qml/pages/AppStorePage.qml
+++ b/app/qml/pages/AppStorePage.qml
@@ -134,6 +134,7 @@ Page {
             }
 
             accessToken: settings.storeAccessToken
+            hardwarePlatform: pebbled.info.platform
 
             onAccessTokenChanged: {
                 settings.storeAccessToken = accessToken;

--- a/daemon/watchconnector.cpp
+++ b/daemon/watchconnector.cpp
@@ -53,6 +53,7 @@ QVariantMap WatchConnector::WatchVersions::toMap() const
         map.insert("bootloader", this->bootLoaderBuild.toTime_t());
         map.insert("serial", this->serialNumber);
         map.insert("address", this->address.toHex());
+        map.insert("platform", this->hardwarePlatform);
         map.insertMulti("firmware", this->main.toMap());
         map.insertMulti("firmware", this->safe.toMap());
     }
@@ -125,6 +126,18 @@ WatchConnector::WatchConnector(QObject *parent) :
         _versions.address = u.readBytes(6);
 
         platform = hardwareMapping.value(_versions.safe.hw_revision).first;
+
+        switch (this->platform) {
+        case APLITE:
+            _versions.hardwarePlatform = "aplite";
+            break;
+        case BASALT:
+            _versions.hardwarePlatform = "basalt";
+            break;
+        case CHALK:
+            _versions.hardwarePlatform = "chalk";
+            break;
+        }
 
         if (u.bad()) {
             qCWarning(l) << "short read while reading firmware version";

--- a/daemon/watchconnector.h
+++ b/daemon/watchconnector.h
@@ -197,6 +197,7 @@ public:
         SoftwareVersion safe;
         QDateTime bootLoaderBuild;
         QString hardwareRevision;
+        QString hardwarePlatform;
         QString serialNumber;
         QByteArray address;
 


### PR DESCRIPTION
Adding support for Pebble Time appstore.

I'm not sure if this 100% work, due to lack of a pebble time, but i use the time boot config and the store lists different categories if i fake a "basalt" platform.