### PR TITLE
Add support for onreadystatechange JS callback from XMLHttpRequest

### DIFF
--- a/daemon/jskitobjects.cpp
+++ b/daemon/jskitobjects.cpp
@@ -413,6 +413,16 @@ void JSKitXMLHttpRequest::setOnload(const QJSValue &value)
     _onload = value;
 }
 
+QJSValue JSKitXMLHttpRequest::onreadystatechange() const
+{
+    return _onreadystatechange;
+}
+
+void JSKitXMLHttpRequest::setOnreadystatechange(const QJSValue &value)
+{
+    _onreadystatechange = value;
+}
+
 QJSValue JSKitXMLHttpRequest::ontimeout() const
 {
     return _ontimeout;
@@ -540,6 +550,16 @@ void JSKitXMLHttpRequest::handleReplyFinished()
         }
     } else {
         qCDebug(l) << "No onload set";
+    }
+
+    if (_onreadystatechange.isCallable()) {
+        qCDebug(l) << "going to call onreadystatechange handler:" << _onreadystatechange.toString();
+        QJSValue result = _onreadystatechange.callWithInstance(_mgr->engine()->newQObject(this));
+        if (result.isError()) {
+            qCWarning(l) << "JS error on onreadystatechange handler:" << JSKitManager::describeError(result);
+        }
+    } else {
+        qCDebug(l) << "No onreadystatechange set";
     }
 }
 

--- a/daemon/jskitobjects.h
+++ b/daemon/jskitobjects.h
@@ -100,6 +100,7 @@ class JSKitXMLHttpRequest : public QObject
 
     Q_PROPERTY(QJSValue onload READ onload WRITE setOnload)
     Q_PROPERTY(QJSValue ontimeout READ ontimeout WRITE setOntimeout)
+    Q_PROPERTY(QJSValue onreadystatechange READ onreadystatechange WRITE setOnreadystatechange)
     Q_PROPERTY(QJSValue onerror READ onerror WRITE setOnerror)
     Q_PROPERTY(uint readyState READ readyState NOTIFY readyStateChanged)
     Q_PROPERTY(uint timeout READ timeout WRITE setTimeout)
@@ -128,6 +129,8 @@ public:
 
     QJSValue onload() const;
     void setOnload(const QJSValue &value);
+    QJSValue onreadystatechange() const;
+    void setOnreadystatechange(const QJSValue &value);
     QJSValue ontimeout() const;
     void setOntimeout(const QJSValue &value);
     QJSValue onerror() const;
@@ -173,6 +176,7 @@ private:
     QJSValue _onload;
     QJSValue _ontimeout;
     QJSValue _onerror;
+    QJSValue _onreadystatechange;
 };
 
 class JSKitGeolocation : public QObject


### PR DESCRIPTION
Some JSKit apps use onreadystatechange to get the results of their web requests, but it wasn't implemented in the pebbled JSKit.

Refs #80 . Probably couldn't be considered a complete fix for that, as there are more unimplemented hooks.