### PR TITLE
Missing JS API components.

### DIFF
--- a/daemon/jskitmanager.cpp
+++ b/daemon/jskitmanager.cpp
@@ -183,7 +183,10 @@ void JSKitManager::startJsApp()
     });
 
     // We try to invoke the callbacks even if script parsing resulted in error...
-    _jspebble->invokeCallbacks("ready");
+    QJSValue eventObj = _engine->newObject();
+    eventObj.setProperty("ready", _engine->toScriptValue(true));
+    eventObj.setProperty("type", "ready");
+    _jspebble->invokeCallbacks("ready", QJSValueList({eventObj}));
 }
 
 void JSKitManager::stopJsApp()

--- a/daemon/jskitobjects.cpp
+++ b/daemon/jskitobjects.cpp
@@ -241,6 +241,11 @@ void JSKitConsole::log(const QString &msg)
     qCDebug(l) << msg;
 }
 
+void JSKitConsole::warn(const QString &msg)
+{
+    qCWarning(l) << msg;
+}
+
 JSKitLocalStorage::JSKitLocalStorage(const QUuid &uuid, QObject *parent)
     : QObject(parent), _storage(new QSettings(getStorageFileFor(uuid), QSettings::IniFormat, this))
 {

--- a/daemon/jskitobjects.h
+++ b/daemon/jskitobjects.h
@@ -61,6 +61,7 @@ public:
     explicit JSKitConsole(QObject *parent=0);
 
     Q_INVOKABLE void log(const QString &msg);
+    Q_INVOKABLE void warn(const QString &msg);
 };
 
 class JSKitLocalStorage : public QObject


### PR DESCRIPTION
The 'ready' event listener callbacks sometimes expect an argument. Pebbled isn't supplying it, and apps that try to access properties of it crash, sometimes before they have initialized themselves properly (e.g. Misfit). I couldn't find any documentation on what the argument should be, but I guess it's an event. I added the properties 'ready' as true and 'type' as "ready", which keeps Misfit happy, but if there's a spec then that would be better.
Also here is an implementation for the warn method of the logging console. Fixes #102 and maybe more.